### PR TITLE
Manage `bp_nav` & `bp_options_nav` backcompat in this plugin

### DIFF
--- a/inc/core/classes/class-bp-classic-core-legacy-nav-backcompat.php
+++ b/inc/core/classes/class-bp-classic-core-legacy-nav-backcompat.php
@@ -1,0 +1,273 @@
+<?php
+/**
+ * Backward compatibility for the $bp->bp_nav global.
+ *
+ * @package bp-classic\inc\groups\classes
+ * @since 1.0.0
+ */
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Backward compatibility class for the `bp_nav` global.
+ *
+ * This class is used to provide backward compatibility for extensions that access and modify
+ * the $bp->bp_nav global.
+ *
+ * @since 1.0.0
+ */
+class BP_Classic_Core_Legacy_Nav_BackCompat implements ArrayAccess {
+	/**
+	 * Nav items.
+	 *
+	 * @since 1.0.0
+	 * @access public
+	 * @var array
+	 */
+	public $backcompat_nav = array();
+
+	/**
+	 * Component to which nav items belong.
+	 *
+	 * @since 1.0.0
+	 * @access public
+	 * @var array
+	 */
+	public $component;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $backcompat_nav Optional. Array of nav items.
+	 */
+	public function __construct( $backcompat_nav = array() ) {
+		foreach ( $backcompat_nav as $key => $value ) {
+			if ( is_array( $value ) ) {
+				$this->backcompat_nav[ $key ] = new self( $value );
+			} else {
+				$this->backcompat_nav[ $key ] = $value;
+			}
+		}
+	}
+
+	/**
+	 * Assign a value to the nav array at the specified offset.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param mixed $offset Array offset.
+	 * @param array $value  Nav item.
+	 */
+	#[ReturnTypeWillChange]
+	public function offsetSet( $offset, $value ) {
+		_doing_it_wrong(
+			'bp_nav',
+			esc_html__( 'The bp_nav and bp_options_nav globals should not be used directly and are deprecated. Please use the BuddyPress nav functions instead.', 'bp-classic' ),
+			'BuddyPress 2.6.0'
+		);
+
+		$bp = buddypress();
+
+		if ( is_array( $value ) ) {
+			$value = new self( $value );
+		}
+
+		if ( null !== $offset ) {
+			// Temporarily set the backcompat_nav.
+			$this->backcompat_nav[ $offset ] = $value;
+
+			$args = $this->to_array();
+			if ( isset( $args['parent_slug'] ) ) {
+				$this->get_component_nav( $args['parent_slug'] )->edit_nav( $args, $args['slug'], $args['parent_slug'] );
+			} elseif ( isset( $args['slug'] ) ) {
+				$bp->members->nav->edit_nav( $args, $args['slug'] );
+			}
+		}
+	}
+
+	/**
+	 * Get a value of the nav array at the specified offset.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param mixed $offset Array offset.
+	 * @return BP_Classic_Core_Legacy_Nav_BackCompat
+	 */
+	#[ReturnTypeWillChange]
+	public function offsetGet( $offset ) {
+		_doing_it_wrong(
+			'bp_nav',
+			esc_html__( 'The bp_nav and bp_options_nav globals should not be used directly and are deprecated. Please use the BuddyPress nav functions instead.', 'bp-classic' ),
+			'BuddyPress 2.6.0'
+		);
+
+		$nav = $this->get_nav( $offset );
+		if ( $nav && isset( $nav[ $offset ] ) ) {
+			$this->backcompat_nav[ $offset ] = new self( $nav[ $offset ] );
+		}
+
+		return $this->backcompat_nav[ $offset ];
+	}
+
+	/**
+	 * Check whether nav array has a value at the specified offset.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param mixed $offset Array offset.
+	 * @return bool
+	 */
+	#[ReturnTypeWillChange]
+	public function offsetExists( $offset ) {
+		_doing_it_wrong(
+			'bp_nav',
+			esc_html__( 'The bp_nav and bp_options_nav globals should not be used directly and are deprecated. Please use the BuddyPress nav functions instead.', 'bp-classic' ),
+			'BuddyPress 2.6.0'
+		);
+
+		if ( isset( $this->backcompat_nav[ $offset ] ) ) {
+			return true;
+		}
+
+		$nav = $this->get_nav( $offset );
+		if ( $nav && isset( $nav[ $offset ] ) ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Unset a nav array value at the specified offset.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param mixed $offset Array offset.
+	 */
+	#[ReturnTypeWillChange]
+	public function offsetUnset( $offset ) {
+		_doing_it_wrong(
+			'bp_nav',
+			esc_html__( 'The bp_nav and bp_options_nav globals should not be used directly and are deprecated. Please use the BuddyPress nav functions instead.', 'bp-classic' ),
+			'BuddyPress 2.6.0'
+		);
+
+		// For top-level nav items, the backcompat nav hasn't yet been initialized.
+		if ( ! isset( $this->backcompat_nav[ $offset ] ) ) {
+			buddypress()->members->nav->delete_nav( $offset );
+			unset( $this->backcompat_nav[ $offset ] );
+		}
+	}
+
+	/**
+	 * Set the component to which the nav belongs.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $component The ID of the component.
+	 */
+	public function set_component( $component ) {
+		$this->component = $component;
+	}
+
+	/**
+	 * Get the component to which the a nav item belongs.
+	 *
+	 * We use the following heuristic to guess, based on an offset, which component the item belongs to:
+	 *   - If this is a group, and the offset is the same as the current group's slug, it's a group nav item.
+	 *   - Otherwise, it's a member nav item.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param mixed $offset Array offset.
+	 * @return string|array
+	 */
+	public function get_component( $offset = '' ) {
+		if ( ! isset( $this->component ) ) {
+			if ( bp_is_active( 'groups' ) && bp_get_current_group_slug() === $offset ) {
+				$this->component = 'groups';
+			} else {
+				$this->component = 'members';
+			}
+		}
+
+		return $this->component;
+	}
+
+	/**
+	 * Reset the cached nav items.
+	 *
+	 * Called when the nav API removes items from the nav array.
+	 *
+	 * @since 1.0.0
+	 */
+	public function reset() {
+		$this->backcompat_nav = array();
+	}
+
+	/**
+	 * Get the nav object corresponding to the specified offset.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param mixed $offset Array offset.
+	 * @return bool|array
+	 */
+	protected function get_nav( $offset ) {
+		$component_nav = $this->get_component_nav( $offset );
+		$primary_nav   = $component_nav->get_primary( array( 'slug' => $offset ), false );
+
+		$nav = array();
+
+		if ( empty( $primary_nav ) ) {
+			return $nav;
+		}
+
+		foreach ( $primary_nav as $item ) {
+			$nav[ $item->slug ] = (array) $item;
+		}
+
+		return $nav;
+	}
+
+	/**
+	 * Get the BP_Core_Nav object corresponding to the component, based on a nav item name.
+	 *
+	 * The way bp_nav was previously organized makes it impossible to know for sure which component's nav is
+	 * being referenced by a given nav item name. We guess in the following manner:
+	 *   - If we're looking at a group, and the nav item name (`$offset`) is the same as the slug of the current
+	 *     group, we assume that the proper component nav is 'groups'.
+	 *   - Otherwise, fall back on 'members'.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $offset Nav item name.
+	 * @return BP_Core_Nav
+	 */
+	protected function get_component_nav( $offset = '' ) {
+		$component = $this->get_component( $offset );
+
+		$bp = buddypress();
+		if ( ! isset( $bp->{$component}->nav ) ) {
+			return false;
+		}
+
+		return $bp->{$component}->nav;
+	}
+
+	/**
+	 * Get the nav data, formatted as a flat array.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array
+	 */
+	protected function to_array() {
+		return $this->backcompat_nav;
+	}
+}

--- a/inc/core/classes/class-bp-classic-core-legacy-options-nav-backcompat.php
+++ b/inc/core/classes/class-bp-classic-core-legacy-options-nav-backcompat.php
@@ -1,0 +1,143 @@
+<?php
+/**
+ * Backward compatibility for the $bp->bp_options_nav global.
+ *
+ * @package bp-classic\inc\groups\classes
+ * @since 1.0.0
+ */
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Backward compatibility class for the deprecated `bp_options_nav` global.
+ *
+ * This class is used to provide backward compatibility for extensions that access and modify
+ * the $bp->bp_options_nav global.
+ *
+ * @since 1.0.0
+ */
+class BP_Classic_Core_Legacy_Options_Nav_BackCompat extends BP_Classic_Core_Legacy_Nav_BackCompat {
+	/**
+	 * Parent slug of the current nav item.
+	 *
+	 * @since 1.0.0
+	 * @access protected
+	 * @var string
+	 */
+	protected $parent_slug = '';
+
+	/**
+	 * Get a value of the nav array at the specified offset.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param mixed $offset Array offset.
+	 * @return BP_Classic_Core_Legacy_Nav_BackCompat
+	 */
+	public function offsetGet( $offset ) {
+		_doing_it_wrong(
+			'bp_nav',
+			esc_html__( 'These globals should not be used directly and are deprecated. Please use the BuddyPress nav functions instead.', 'bp-classic' ),
+			'BuddyPress 2.6.0'
+		);
+
+		if ( empty( $this->backcompat_nav[ $offset ] ) ) {
+			$nav = $this->get_nav( $offset );
+			if ( $nav ) {
+				$subnavs      = $this->get_component_nav( $offset )->get_secondary( array( 'parent_slug' => $offset ) );
+				$subnav_keyed = array();
+				if ( $subnavs ) {
+					foreach ( $subnavs as $subnav ) {
+						$subnav_keyed[ $subnav->slug ] = (array) $subnav;
+					}
+				}
+
+				$subnav_object = new self( $subnav_keyed );
+				$subnav_object->set_component( $this->get_component() );
+				$subnav_object->set_parent_slug( $offset );
+
+				$this->backcompat_nav[ $offset ] = $subnav_object;
+			}
+		}
+
+		if ( isset( $this->backcompat_nav[ $offset ] ) ) {
+			return $this->backcompat_nav[ $offset ];
+		}
+
+		return false;
+	}
+
+	/**
+	 * Unset a nav array value at the specified offset.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param mixed $offset Array offset.
+	 */
+	public function offsetUnset( $offset ) {
+		_doing_it_wrong(
+			'bp_nav',
+			esc_html__( 'These globals should not be used directly and are deprecated. Please use the BuddyPress nav functions instead.', 'bp-classic' ),
+			'BuddyPress 2.6.0'
+		);
+
+		$this->get_component_nav( $offset )->delete_nav( $offset, $this->get_parent_slug() );
+
+		// Clear the cached nav.
+		unset( $this->backcompat_nav[ $offset ] );
+	}
+
+	/**
+	 * Get the parent slug of the current nav item.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string
+	 */
+	public function get_parent_slug() {
+		return $this->parent_slug;
+	}
+
+	/**
+	 * Set the parent slug of the current nav item.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $slug The parent navigation slug.
+	 */
+	public function set_parent_slug( $slug ) {
+		$this->parent_slug = $slug;
+	}
+
+	/**
+	 * Get the nav object corresponding to the specified offset.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param mixed $offset Array offset.
+	 * @return bool|array
+	 */
+	public function get_nav( $offset ) {
+		$nav = parent::get_nav( $offset );
+
+		if ( ! $nav ) {
+			$component_nav = $this->get_component_nav( $offset );
+			$secondary_nav = $component_nav->get_secondary( array( 'slug' => $offset ), false );
+
+			$nav = array();
+
+			if ( empty( $secondary_nav ) ) {
+				return $nav;
+			}
+
+			foreach ( $secondary_nav as $item ) {
+				$nav[ $item->slug ] = (array) $item;
+			}
+		}
+
+		return $nav;
+	}
+}

--- a/inc/core/filters.php
+++ b/inc/core/filters.php
@@ -71,3 +71,32 @@ function bp_classic_default_theme_root_uri( $theme_root_uri, $siteurl, $styleshe
 	return $theme_root_uri;
 }
 add_filter( 'theme_root_uri', 'bp_classic_default_theme_root_uri', 10, 3 );
+
+/**
+ * Inits Legacy navigation to preserve backward compatibility with BP < 2.6 code.
+ *
+ * @since 1.0.0
+ */
+function bp_classic_init_legacy_backcompat_nav() {
+	$bp = buddypress();
+
+	// Backward compatibility for plugins modifying the legacy bp_nav and bp_options_nav global properties.
+	$bp->bp_nav         = new BP_Classic_Core_Legacy_Nav_BackCompat();
+	$bp->bp_options_nav = new BP_Classic_Core_Legacy_Options_Nav_BackCompat();
+}
+add_action( 'bp_core_setup_globals', 'bp_classic_init_legacy_backcompat_nav', 1 );
+
+/**
+ * Resets the Legacy navigation when a nav or subnav item was removed.
+ *
+ * @since 1.0.0
+ */
+function bp_classic_reset_legacy_backcompat_nav() {
+	$bp = buddypress();
+
+	// Reset backcompat nav items so that subsequent references will be correct.
+	$bp->bp_nav->reset();
+	$bp->bp_options_nav->reset();
+}
+add_action( 'bp_core_removed_nav_item', 'bp_classic_reset_legacy_backcompat_nav', 1, 0 );
+add_action( 'bp_core_removed_subnav_item', 'bp_classic_reset_legacy_backcompat_nav', 1, 0 );

--- a/tests/phpunit/testcases/classes/testBPClassicLegacyNavBackCompat.php
+++ b/tests/phpunit/testcases/classes/testBPClassicLegacyNavBackCompat.php
@@ -1,0 +1,1055 @@
+<?php
+
+/**
+ * @group core
+ * @group nav
+ * @expectedIncorrectUsage bp_nav
+ */
+class BP_Classic_Legacy_Nav_BackCompat extends BP_UnitTestCase {
+	protected $bp_nav;
+	protected $bp_options_nav;
+	protected $permalink_structure = '';
+
+	public function set_up() {
+		parent::set_up();
+		$this->bp_nav = buddypress()->bp_nav;
+		$this->bp_options_nav = buddypress()->bp_options_nav;
+		$this->permalink_structure = get_option( 'permalink_structure', '' );
+	}
+
+	public function tear_down() {
+		buddypress()->bp_nav = $this->bp_nav;
+		buddypress()->bp_options_nav = $this->bp_options_nav;
+		$this->set_permalink_structure( $this->permalink_structure );
+		parent::tear_down();
+	}
+
+	protected function create_nav_items() {
+		bp_core_new_nav_item( array(
+			'name'                => 'Foo',
+			'slug'                => 'foo',
+			'position'            => 25,
+			'screen_function'     => 'foo_screen_function',
+			'default_subnav_slug' => 'foo-subnav'
+		) );
+
+		bp_core_new_subnav_item( array(
+			'name'            => 'Foo Subnav',
+			'slug'            => 'foo-subnav',
+			'parent_url'      => 'example.com/foo',
+			'parent_slug'     => 'foo',
+			'screen_function' => 'foo_screen_function',
+			'position'        => 10
+		) );
+	}
+
+	/**
+	 * Create a group, set up nav item, and go to the group.
+	 */
+	protected function set_up_group() {
+		$this->set_permalink_structure( '/%postname%/' );
+		$g = self::factory()->group->create( array(
+			'slug' => 'testgroup',
+		) );
+
+		$group = groups_get_group( $g );
+		$group_permalink = bp_get_group_url( $group );
+
+		$this->go_to( $group_permalink );
+
+		bp_core_new_subnav_item( array(
+			'name'            => 'Foo',
+			'slug'            => 'foo',
+			'parent_url'      => $group_permalink,
+			'parent_slug'     => 'testgroup',
+			'screen_function' => 'foo_screen_function',
+			'position'        => 10
+		), 'groups' );
+	}
+
+	public function test_bp_nav_isset() {
+		$this->create_nav_items();
+
+		$bp = buddypress();
+
+		$this->assertTrue( isset( $bp->bp_nav ) );
+		$this->assertTrue( isset( $bp->bp_nav['foo'] ) );
+		$this->assertTrue( isset( $bp->bp_nav['foo']['name'] ) );
+	}
+
+	public function test_bp_nav_unset() {
+		$this->create_nav_items();
+
+		$bp = buddypress();
+
+		// No support for this - it would create a malformed nav item.
+		/*
+		unset( $bp->bp_nav['foo']['css_id'] );
+		$this->assertFalse( isset( $bp->bp_nav['foo']['css_id'] ) );
+		*/
+
+		unset( $bp->bp_nav['foo'] );
+		$this->assertFalse( isset( $bp->bp_nav['foo'] ) );
+	}
+
+	public function test_bp_nav_get() {
+		$this->create_nav_items();
+
+		$bp = buddypress();
+
+		$foo = $bp->bp_nav['foo'];
+		$this->assertSame( 'Foo', $foo['name'] );
+
+		$this->assertSame( 'Foo', $bp->bp_nav['foo']['name'] );
+	}
+
+	public function test_bp_nav_set() {
+		$this->create_nav_items();
+
+		$bp = buddypress();
+
+		$bp->bp_nav['foo']['name'] = 'Bar';
+
+		$nav = bp_get_nav_menu_items();
+
+		foreach ( $nav as $_nav ) {
+			if ( 'foo' === $_nav->css_id ) {
+				$found = $_nav;
+				break;
+			}
+		}
+
+		$this->assertSame( 'Bar', $found->name );
+	}
+
+	public function test_bp_options_nav_isset() {
+		$this->create_nav_items();
+
+		$bp = buddypress();
+
+		$this->assertTrue( isset( $bp->bp_options_nav ) );
+		$this->assertTrue( isset( $bp->bp_options_nav['foo'] ) );
+		$this->assertTrue( isset( $bp->bp_options_nav['foo']['foo-subnav'] ) );
+		$this->assertTrue( isset( $bp->bp_options_nav['foo']['foo-subnav']['name'] ) );
+	}
+
+	public function test_bp_options_nav_unset() {
+		$this->create_nav_items();
+
+		$bp = buddypress();
+
+		// No support for this - it would create a malformed nav item.
+		/*
+		unset( $bp->bp_options_nav['foo']['foo-subnav']['user_has_access'] );
+		$this->assertFalse( isset( $bp->bp_options_nav['foo']['foo-subnav']['user_has_access'] ) );
+		*/
+
+		unset( $bp->bp_options_nav['foo']['foo-subnav'] );
+		$this->assertFalse( isset( $bp->bp_options_nav['foo']['foo-subnav'] ) );
+
+		// Make sure the parent nav hasn't been wiped out.
+		$this->assertTrue( isset( $bp->bp_options_nav['foo'] ) );
+
+		unset( $bp->bp_options_nav['foo'] );
+		$this->assertFalse( isset( $bp->bp_options_nav['foo'] ) );
+	}
+
+	public function test_bp_options_nav_get() {
+		$this->create_nav_items();
+
+		$bp = buddypress();
+
+		$foo_subnav = $bp->bp_options_nav['foo']['foo-subnav'];
+		$this->assertSame( 'Foo Subnav', $foo_subnav['name'] );
+
+		$this->assertSame( 'Foo Subnav', $bp->bp_options_nav['foo']['foo-subnav']['name'] );
+	}
+
+	public function test_bp_options_nav_set() {
+		$this->create_nav_items();
+
+		$bp = buddypress();
+
+		$bp->bp_options_nav['foo']['foo-subnav']['name'] = 'Bar';
+		$nav = bp_get_nav_menu_items();
+
+		foreach ( $nav as $_nav ) {
+			if ( 'foo-subnav' === $_nav->css_id ) {
+				$found = $_nav;
+				break;
+			}
+		}
+
+		$this->assertSame( 'Bar', $found->name );
+
+		$subnav = array(
+			'name' => 'Bar',
+			'css_id' => 'bar-id',
+			'link' => 'bar-link',
+			'slug' => 'bar-slug',
+			'user_has_access' => true,
+		);
+		$bp->bp_options_nav['foo']['foo-subnav'] = $subnav;
+		$nav = bp_get_nav_menu_items();
+
+		foreach ( $nav as $_nav ) {
+			if ( 'bar-id' === $_nav->css_id ) {
+				$found = $_nav;
+				break;
+			}
+		}
+
+		$this->assertSame( 'Bar', $found->name );
+	}
+
+	/**
+	 * @group groups
+	 */
+	public function test_bp_options_nav_isset_group_nav() {
+		$this->markTestSkipped();
+		$this->set_up_group();
+
+		$bp = buddypress();
+
+		$this->assertTrue( isset( $bp->bp_options_nav ) );
+		$this->assertTrue( isset( $bp->bp_options_nav['testgroup'] ) );
+		$this->assertTrue( isset( $bp->bp_options_nav['testgroup']['foo'] ) );
+		$this->assertTrue( isset( $bp->bp_options_nav['testgroup']['foo']['name'] ) );
+	}
+
+	/**
+	 * @group groups
+	 */
+	public function test_bp_options_nav_unset_group_nav() {
+		$this->markTestSkipped();
+		$this->set_up_group();
+
+		$bp = buddypress();
+
+		// No support for this - it would create a malformed nav item.
+		/*
+		unset( $bp->bp_options_nav['testgroup']['foo']['user_has_access'] );
+		$this->assertFalse( isset( $bp->bp_options_nav['testgroup']['foo']['user_has_access'] ) );
+		*/
+
+		unset( $bp->bp_options_nav['testgroup']['foo'] );
+		$this->assertFalse( isset( $bp->bp_options_nav['testgroup']['foo'] ) );
+
+		unset( $bp->bp_options_nav['testgroup'] );
+		$this->assertFalse( isset( $bp->bp_options_nav['testgroup'] ) );
+	}
+
+	/**
+	 * @group groups
+	 */
+	public function test_bp_options_nav_get_group_nav() {
+		$this->markTestSkipped();
+		$this->set_up_group();
+
+		$bp = buddypress();
+
+		$foo = $bp->bp_options_nav['testgroup']['foo'];
+		$this->assertSame( 'Foo', $foo['name'] );
+
+		$this->assertSame( 'Foo', $bp->bp_options_nav['testgroup']['foo']['name'] );
+	}
+
+	/**
+	 * @group groups
+	 */
+	public function test_bp_options_nav_set_group_nav() {
+		$this->markTestSkipped();
+		$this->set_up_group();
+
+		$bp = buddypress();
+
+		$bp->bp_options_nav['testgroup']['foo']['name'] = 'Bar';
+		$nav = bp_get_nav_menu_items( 'groups' );
+
+		foreach ( $nav as $_nav ) {
+			if ( 'foo' === $_nav->css_id ) {
+				$found = $_nav;
+				break;
+			}
+		}
+
+		$this->assertSame( 'Bar', $found->name );
+
+		$subnav = array(
+			'name' => 'Bar',
+			'css_id' => 'bar-id',
+			'link' => 'bar-link',
+			'slug' => 'bar-slug',
+			'user_has_access' => true,
+		);
+		$bp->bp_options_nav['testgroup']['foo'] = $subnav;
+		$nav = bp_get_nav_menu_items( 'groups' );
+
+		foreach ( $nav as $_nav ) {
+			if ( 'bar-id' === $_nav->css_id ) {
+				$found = $_nav;
+				break;
+			}
+		}
+
+		$this->assertSame( 'Bar', $found->name );
+	}
+
+	/**
+	 * @group groups
+	 */
+	public function test_bp_core_new_subnav_item_should_work_in_group_context() {
+		$this->markTestSkipped();
+		$this->set_up_group();
+
+		bp_core_new_subnav_item( array(
+			'name' => 'Foo Subnav',
+			'slug' => 'foo-subnav',
+			'parent_slug' => bp_get_current_group_slug(),
+			'parent_url' => bp_get_group_url( groups_get_current_group() ),
+			'screen_function' => 'foo_subnav',
+		) );
+
+		$bp = buddypress();
+
+		// Touch bp_nav since we told PHPUnit it was expectedDeprecated.
+		$f = $bp->bp_options_nav[ bp_get_current_group_slug() ];
+
+		$nav = bp_get_nav_menu_items( 'groups' );
+
+		foreach ( $nav as $_nav ) {
+			if ( 'foo-subnav' === $_nav->css_id ) {
+				$found = $_nav;
+				break;
+			}
+		}
+
+		$this->assertSame( 'Foo Subnav', $found->name );
+	}
+
+	/**
+	 * @expectedIncorrectUsage bp_nav
+	 */
+	public function test_user_nav() {
+		$this->markTestSkipped();
+		$bp_nav = buddypress()->bp_nav;
+
+		$u = self::factory()->user->create();
+		$old_current_user = get_current_user_id();
+		$this->set_current_user( $u );
+		$this->set_permalink_structure( '/%postname%/' );
+
+		$this->go_to( bp_members_get_user_url( $u ) );
+
+		bp_core_new_nav_item( array(
+			'name'                    => 'Foo',
+			'slug'                    => 'foo',
+			'position'                => 25,
+			'screen_function'         => 'foo_screen_function',
+			'default_subnav_slug'     => 'foo-sub'
+		) );
+
+		$expected = array(
+			'name'                    => 'Foo',
+			'slug'                    => 'foo',
+			'link'                    => bp_members_get_user_url(
+				$u,
+				array(
+					'single_item_component' => 'foo',
+				)
+			),
+			'css_id'                  => 'foo',
+			'show_for_displayed_user' => true,
+			'position'                => 25,
+			'screen_function'         => 'foo_screen_function',
+			'default_subnav_slug'     => 'foo-sub'
+		);
+
+		foreach ( $expected as $k => $v ) {
+			$this->assertEquals( $v, buddypress()->bp_nav['foo'][ $k ] );
+		}
+
+		// Clean up
+		buddypress()->bp_nav = $bp_nav;
+		$this->set_current_user( $old_current_user );
+	}
+
+	/**
+	 * @expectedIncorrectUsage bp_nav
+	 */
+	public function test_group_nav() {
+		$this->markTestSkipped();
+		$bp_nav = buddypress()->bp_nav;
+
+		$u = self::factory()->user->create();
+		$g = self::factory()->group->create();
+		$old_current_user = get_current_user_id();
+		$this->set_current_user( $u );
+		$this->set_permalink_structure( '/%postname%/' );
+
+		$group = groups_get_group( $g );
+
+		$this->go_to( bp_get_group_url( $group ) );
+
+		$this->assertTrue( buddypress()->bp_nav[ $group->slug ]['position'] === -1 );
+
+		// Clean up
+		buddypress()->bp_nav = $bp_nav;
+		$this->set_current_user( $old_current_user );
+	}
+
+	/**
+	 * @expectedIncorrectUsage bp_nav
+	 */
+	public function test_css_id_should_fall_back_on_slug() {
+		$args = array(
+			'name' => 'Foo',
+			'slug' => 'foo',
+		);
+		bp_core_new_nav_item( $args );
+
+		$this->assertSame( 'foo', buddypress()->bp_nav['foo']['css_id'] );
+	}
+
+	/**
+	 * @expectedIncorrectUsage bp_nav
+	 */
+	public function test_css_id_should_be_respected() {
+		$args = array(
+			'name' => 'Foo',
+			'slug' => 'foo',
+			'item_css_id' => 'bar',
+		);
+		bp_core_new_nav_item( $args );
+
+		$this->assertSame( 'bar', buddypress()->bp_nav['foo']['css_id'] );
+	}
+
+	/**
+	 * @expectedIncorrectUsage bp_nav
+	 */
+	public function test_existence_of_access_protected_user_nav() {
+		$this->markTestSkipped();
+		$bp_nav = buddypress()->bp_nav;
+
+		$u = self::factory()->user->create();
+		$u2 = self::factory()->user->create();
+		$old_current_user = get_current_user_id();
+		$this->set_current_user( $u2 );
+		$this->set_permalink_structure( '/%postname%/' );
+
+		$this->go_to( bp_members_get_user_url( $u ) );
+
+		$expected = array(
+			'name'                    => 'Settings',
+			'slug'                    => 'settings',
+			'link'                    => bp_members_get_user_url(
+				$u,
+				array(
+					'single_item_component' => 'settings',
+				)
+			),
+			'css_id'                  => 'settings',
+			'show_for_displayed_user' => false,
+			'position'                => 100,
+			'screen_function'         => 'bp_settings_screen_general',
+			'default_subnav_slug'     => 'general'
+		);
+
+		foreach ( $expected as $k => $v ) {
+			$this->assertEquals( $v, buddypress()->bp_nav['settings'][ $k ] );
+		}
+
+		// Clean up
+		buddypress()->bp_nav = $bp_nav;
+		$this->set_current_user( $old_current_user );
+	}
+
+	/**
+	 * @expectedIncorrectUsage bp_nav
+	 */
+	public function test_creation_of_access_protected_user_nav() {
+		$this->markTestSkipped();
+		// The nav item must be added to bp_nav, even if the current user
+		// can't visit that nav item.
+		$bp_nav = buddypress()->bp_nav;
+
+		$u = self::factory()->user->create();
+		$u2 = self::factory()->user->create();
+		$old_current_user = get_current_user_id();
+		$this->set_current_user( $u2 );
+		$this->set_permalink_structure( '/%postname%/' );
+
+		$this->go_to( bp_members_get_user_url( $u ) );
+
+		bp_core_new_nav_item( array(
+			'name'                    => 'Woof',
+			'slug'                    => 'woof',
+			'show_for_displayed_user' => false,
+			'position'                => 35,
+			'screen_function'         => 'woof_screen_function',
+			'default_subnav_slug'     => 'woof-one'
+		) );
+
+		$expected = array(
+			'name'                    => 'Woof',
+			'slug'                    => 'woof',
+			'link'                    => bp_members_get_user_url(
+				$u,
+				array(
+					'single_item_component' => 'woof',
+				)
+			),
+			'css_id'                  => 'woof',
+			'show_for_displayed_user' => false,
+			'position'                => 35,
+			'screen_function'         => 'woof_screen_function',
+			'default_subnav_slug'     => 'woof-one'
+		);
+
+		foreach ( $expected as $k => $v ) {
+			$this->assertEquals( $v, buddypress()->bp_nav['woof'][ $k ] );
+		}
+
+		// Clean up
+		buddypress()->bp_nav = $bp_nav;
+		$this->set_current_user( $old_current_user );
+	}
+
+	/**
+	 * @expectedIncorrectUsage bp_nav
+	 */
+	public function test_user_subnav() {
+		$this->set_permalink_structure( '/%postname%/' );
+		$bp_options_nav = buddypress()->bp_options_nav;
+
+		$u = self::factory()->user->create();
+		$old_current_user = get_current_user_id();
+		$this->set_current_user( $u );
+
+		$this->go_to( bp_members_get_user_url( $u ) );
+
+		bp_core_new_nav_item( array(
+			'name'            => 'Foo Parent',
+			'slug'            => 'foo-parent',
+			'screen_function' => 'foo_screen_function',
+			'position'        => 10,
+		) );
+
+		bp_core_new_subnav_item( array(
+			'name'            => 'Foo',
+			'slug'            => 'foo',
+			'parent_url'      => bp_members_get_user_url(
+				$u,
+				array(
+					'single_item_component' => 'foo-parent',
+				)
+			),
+			'parent_slug'     => 'foo-parent',
+			'screen_function' => 'foo_screen_function',
+			'position'        => 10
+		) );
+
+		$expected = array(
+			'name'              => 'Foo',
+			'link'              => bp_members_get_user_url(
+				$u,
+				array(
+					'single_item_component' => 'foo-parent',
+					'single_item_action'    => 'foo',
+				)
+			),
+			'slug'              => 'foo',
+			'css_id'            => 'foo',
+			'position'          => 10,
+			'user_has_access'   => true,
+			'no_access_url'     => '',
+			'screen_function'   => 'foo_screen_function',
+			'show_in_admin_bar' => false,
+		);
+
+		foreach ( $expected as $k => $v ) {
+			$this->assertSame( $v, buddypress()->bp_options_nav['foo-parent']['foo'][ $k ] );
+		}
+
+		// Clean up
+		buddypress()->bp_options_nav = $bp_options_nav;
+		$this->set_current_user( $old_current_user );
+	}
+
+	/**
+	 * @expectedIncorrectUsage bp_nav
+	 */
+	public function test_link_provided() {
+		$bp_options_nav = buddypress()->bp_options_nav;
+
+		bp_core_new_nav_item( array(
+			'name' => 'Foo',
+			'slug' => 'foo',
+			'screen_function' => 'foo',
+			'link' => 'https://buddypress.org/',
+		) );
+
+		bp_core_new_subnav_item( array(
+			'name' => 'bar',
+			'slug' => 'bar',
+			'parent_slug' => 'foo',
+			'parent_url' => 'foo',
+			'screen_function' => 'foo',
+			'link' => 'https://buddypress.org/',
+		) );
+
+		$this->assertSame( 'https://buddypress.org/', buddypress()->bp_options_nav['foo']['bar']['link'] );
+
+		buddypress()->bp_options_nav = $bp_options_nav;
+	}
+
+	/**
+	 * @expectedIncorrectUsage bp_nav
+	 */
+	public function test_link_built_from_parent_url_and_slug() {
+		$bp_options_nav = buddypress()->bp_options_nav;
+
+		bp_core_new_nav_item( array(
+			'name' => 'Foo',
+			'slug' => 'foo',
+			'screen_function' => 'foo',
+			'link' => 'https://buddypress.org/',
+		) );
+
+		bp_core_new_subnav_item( array(
+			'name' => 'bar',
+			'slug' => 'bar',
+			'parent_slug' => 'foo',
+			'parent_url' => 'http://example.com/foo/',
+			'screen_function' => 'foo',
+		) );
+
+		$this->assertSame( 'http://example.com/foo/bar/', buddypress()->bp_options_nav['foo']['bar']['link'] );
+
+		buddypress()->bp_options_nav = $bp_options_nav;
+	}
+
+	/**
+	 * @expectedIncorrectUsage bp_nav
+	 */
+	public function test_link_built_from_parent_url_and_slug_where_slug_is_default() {
+		$bp_nav = buddypress()->bp_nav;
+		$bp_options_nav = buddypress()->bp_options_nav;
+
+		bp_core_new_nav_item( array(
+			'name' => 'Foo',
+			'slug' => 'foo',
+			'url' => 'http://example.com/foo/',
+			'screen_function' => 'foo',
+			'default_subnav_slug' => 'bar',
+		) );
+
+		bp_core_new_subnav_item( array(
+			'name' => 'bar',
+			'slug' => 'bar',
+			'parent_slug' => 'foo',
+			'parent_url' => 'http://example.com/foo/',
+			'screen_function' => 'foo',
+		) );
+
+		$this->assertSame( 'http://example.com/foo/bar/', buddypress()->bp_options_nav['foo']['bar']['link'] );
+
+		// clean up
+		buddypress()->bp_nav = $bp_nav;
+		buddypress()->bp_options_nav = $bp_options_nav;
+	}
+
+	/**
+	 * @expectedIncorrectUsage bp_nav
+	 */
+	public function test_should_trailingslash_link_when_link_is_autogenerated_using_slug() {
+		$this->set_permalink_structure( '/%postname%/' );
+		bp_core_new_nav_item( array(
+			'name' => 'Foo',
+			'slug' => 'foo',
+			'screen_function' => 'foo',
+			'link' => 'https://buddypress.org/',
+		) );
+
+		bp_core_new_subnav_item( array(
+			'name' => 'bar',
+			'slug' => 'bar',
+			'parent_slug' => 'foo',
+			'parent_url' => bp_get_root_url() . 'foo/',
+			'screen_function' => 'foo',
+		) );
+
+		$expected = bp_get_root_url() . 'foo/bar/';
+		$this->assertSame( $expected, buddypress()->bp_options_nav['foo']['bar']['link'] );
+	}
+
+	/**
+	 * @expectedIncorrectUsage bp_nav
+	 */
+	public function test_should_trailingslash_link_when_link_is_autogenerated_not_using_slug() {
+		$this->set_permalink_structure( '/%postname%/' );
+		bp_core_new_nav_item( array(
+			'name' => 'foo',
+			'slug' => 'foo-parent',
+			'link' => bp_get_root_url() . 'foo-parent/',
+			'default_subnav_slug' => 'bar',
+			'screen_function' => 'foo',
+		) );
+
+		bp_core_new_subnav_item( array(
+			'name' => 'bar',
+			'slug' => 'bar',
+			'parent_slug' => 'foo-parent',
+			'parent_url' => bp_get_root_url() . '/foo-parent/',
+			'screen_function' => 'bar',
+		) );
+
+		$expected = bp_get_root_url() . '/foo-parent/bar/';
+		$this->assertSame( $expected, buddypress()->bp_options_nav['foo-parent']['bar']['link'] );
+	}
+
+	/**
+	 * @ticket BP6353
+	 * @expectedIncorrectUsage bp_nav
+	 */
+	public function test_link_should_not_trailingslash_link_explicit_link() {
+		$link = 'http://example.com/foo/bar/blah/?action=edit&id=30';
+
+		bp_core_new_nav_item( array(
+			'name' => 'Foo',
+			'slug' => 'foo',
+			'screen_function' => 'foo',
+			'link' => 'http://example.com/foo/',
+		) );
+
+		bp_core_new_subnav_item( array(
+			'name' => 'bar',
+			'slug' => 'bar',
+			'parent_slug' => 'foo',
+			'parent_url' => 'http://example.com/foo/',
+			'screen_function' => 'foo',
+			'link' => $link,
+		) );
+
+		$this->assertSame( $link, buddypress()->bp_options_nav['foo']['bar']['link'] );
+	}
+
+	/**
+	 * @expectedIncorrectUsage bp_nav
+	 */
+	public function test_css_id_should_fallback_on_slug() {
+		bp_core_new_nav_item( array(
+			'name' => 'Parent',
+			'slug' => 'parent',
+			'screen_function' => 'foo',
+		) );
+
+		$args = array(
+			'name' => 'Foo',
+			'slug' => 'foo',
+			'parent_slug' => 'parent',
+			'parent_url' => bp_get_root_url() . '/parent/',
+			'screen_function' => 'foo',
+		);
+		bp_core_new_subnav_item( $args );
+
+		$this->assertSame( 'foo', buddypress()->bp_options_nav['parent']['foo']['css_id'] );
+	}
+
+	/**
+	 * @expectedIncorrectUsage bp_nav
+	 */
+	public function test_css_id_should_still_be_respected() {
+		bp_core_new_nav_item( array(
+			'name' => 'Parent',
+			'slug' => 'parent',
+			'screen_function' => 'foo',
+		) );
+
+		$args = array(
+			'name' => 'Foo',
+			'slug' => 'foo',
+			'parent_slug' => 'parent',
+			'parent_url' => bp_get_root_url() . '/parent/',
+			'screen_function' => 'foo',
+			'item_css_id' => 'bar',
+		);
+		bp_core_new_subnav_item( $args );
+
+		$this->assertSame( 'bar', buddypress()->bp_options_nav['parent']['foo']['css_id'] );
+	}
+
+	/**
+	 * @expectedIncorrectUsage bp_nav
+	 */
+	public function test_should_remove_subnav_items() {
+		$bp = buddypress();
+
+		$_bp_nav = $bp->bp_nav;
+		$_bp_options_nav = $bp->bp_options_nav;
+
+		bp_core_new_nav_item( array(
+			'name' => 'Foo',
+			'slug' => 'foo',
+			'screen_function' => 'foo',
+		) );
+
+		bp_core_new_subnav_item( array(
+			'name' => 'Bar',
+			'slug' => 'bar',
+			'parent_slug' => 'foo',
+			'parent_url' => 'foo',
+			'screen_function' => 'bar',
+		) );
+
+		$this->assertTrue( isset( $bp->bp_nav['foo'] ) );
+		$this->assertTrue( isset( $bp->bp_options_nav['foo'] ) );
+		$this->assertTrue( isset( $bp->bp_options_nav['foo']['bar'] ) );
+
+		bp_core_remove_nav_item( 'foo' );
+
+		$this->assertFalse( isset( $bp->bp_options_nav['foo']['bar'] ) );
+
+		$bp->bp_nav = $_bp_nav;
+		$bp->bp_options_nav = $_bp_options_nav;
+	}
+
+	/**
+	 * @expectedIncorrectUsage bp_nav
+	 */
+	public function test_should_remove_nav_item() {
+		$bp = buddypress();
+
+		$_bp_nav = $bp->bp_nav;
+		$_bp_options_nav = $bp->bp_options_nav;
+
+		bp_core_new_nav_item( array(
+			'name' => 'Foo',
+			'slug' => 'foo',
+			'screen_function' => 'foo',
+		) );
+
+		$this->assertTrue( isset( $bp->bp_nav['foo'] ) );
+
+		bp_core_remove_nav_item( 'foo' );
+
+		$this->assertFalse( isset( $bp->bp_nav['foo'] ) );
+
+		$bp->bp_nav = $_bp_nav;
+		$bp->bp_options_nav = $_bp_options_nav;
+	}
+
+	/**
+	 * @expectedIncorrectUsage bp_nav
+	 */
+	public function test_should_remove_subnav_item() {
+		$bp = buddypress();
+
+		$_bp_nav = $bp->bp_nav;
+		$_bp_options_nav = $bp->bp_options_nav;
+
+		bp_core_new_nav_item( array(
+			'name' => 'Foo',
+			'slug' => 'foo',
+			'screen_function' => 'foo',
+		) );
+
+		bp_core_new_subnav_item( array(
+			'name' => 'Bar',
+			'slug' => 'bar',
+			'parent_slug' => 'foo',
+			'parent_url' => 'foo',
+			'screen_function' => 'bar',
+		) );
+
+		$this->assertTrue( isset( $bp->bp_options_nav['foo']['bar'] ) );
+
+		bp_core_remove_subnav_item( 'foo', 'bar' );
+
+		$this->assertFalse( isset( $bp->bp_options_nav['foo']['bar'] ) );
+
+		$bp->bp_nav = $_bp_nav;
+		$bp->bp_options_nav = $_bp_options_nav;
+	}
+
+	/**
+	 * @expectedIncorrectUsage bp_nav
+	 */
+	public function test_should_fail_on_incorrect_parent() {
+		$bp = buddypress();
+
+		$_bp_nav = $bp->bp_nav;
+		$_bp_options_nav = $bp->bp_options_nav;
+
+		bp_core_new_nav_item( array(
+			'name' => 'Foo',
+			'slug' => 'foo',
+			'screen_function' => 'foo',
+		) );
+
+		bp_core_new_subnav_item( array(
+			'name' => 'Bar',
+			'slug' => 'bar',
+			'parent_slug' => 'foo',
+			'parent_url' => 'foo',
+			'screen_function' => 'bar',
+		) );
+
+		$this->assertTrue( isset( $bp->bp_options_nav['foo']['bar'] ) );
+
+		bp_core_remove_subnav_item( 'bad-parent', 'bar' );
+
+		$this->assertTrue( isset( $bp->bp_options_nav['foo']['bar'] ) );
+
+		$bp->bp_nav = $_bp_nav;
+		$bp->bp_options_nav = $_bp_options_nav;
+	}
+
+	/**
+	 * @group enable_nav_item
+	 * @expectedIncorrectUsage bp_nav
+	 */
+	public function test_enable_nav_item_true() {
+		$this->markTestSkipped();
+		$old_options_nav = buddypress()->bp_options_nav;
+		$this->set_permalink_structure( '/%postname%/' );
+
+		$g = self::factory()->group->create();
+		$g_obj = groups_get_group( $g );
+
+		$class_name = 'BPTest_Group_Extension_Enable_Nav_Item_True';
+		$e = new $class_name();
+
+		$this->go_to( bp_get_group_url( $g_obj ) );
+
+		$e->_register();
+
+		$this->assertTrue( isset( buddypress()->bp_options_nav[ $g_obj->slug ][ $e->slug ] ) );
+
+		// Clean up
+		buddypress()->bp_options_nav = $old_options_nav;
+	}
+
+	/**
+	 * @group enable_nav_item
+	 * @expectedIncorrectUsage bp_nav
+	 */
+	public function test_enable_nav_item_false() {
+		$this->markTestSkipped();
+		$this->set_permalink_structure( '/%postname%/' );
+		$old_options_nav = buddypress()->bp_options_nav;
+
+		$g = self::factory()->group->create();
+		$g_obj = groups_get_group( $g );
+
+		$class_name = 'BPTest_Group_Extension_Enable_Nav_Item_False';
+		$e = new $class_name();
+
+		$this->go_to( bp_get_group_url( $g_obj ) );
+
+		$e->_register();
+
+		$this->assertFalse( isset( buddypress()->bp_options_nav[ $g_obj->slug ][ $e->slug ] ) );
+
+		// Clean up
+		buddypress()->bp_options_nav = $old_options_nav;
+	}
+
+	/**
+	 * @group visibility
+	 * @expectedIncorrectUsage bp_nav
+	 */
+	public function test_visibility_private() {
+		$this->markTestSkipped();
+		$this->set_permalink_structure( '/%postname%/' );
+		$old_options_nav = buddypress()->bp_options_nav;
+		$old_current_user = get_current_user_id();
+
+		$g = self::factory()->group->create( array(
+			'status' => 'private',
+		) );
+		$g_obj = groups_get_group( $g );
+
+		$class_name = 'BPTest_Group_Extension_Visibility_Private';
+		$e = new $class_name();
+
+		// Test as non-logged-in user
+		$this->set_current_user( 0 );
+		$this->go_to( bp_get_group_url( $g_obj ) );
+		$e->_register();
+		$this->assertFalse( isset( buddypress()->bp_options_nav[ $g_obj->slug ][ $e->slug ] ) );
+
+		// Clean up
+		buddypress()->bp_options_nav = $old_options_nav;
+
+		// Test as group member
+		$u = self::factory()->user->create();
+		$this->set_current_user( $u );
+		$this->add_user_to_group( $u, $g );
+		$this->go_to( bp_get_group_url( $g_obj ) );
+		$e->_register();
+		$this->assertTrue( isset( buddypress()->bp_options_nav[ $g_obj->slug ][ $e->slug ] ) );
+
+		// Clean up
+		buddypress()->bp_options_nav = $old_options_nav;
+		$this->set_current_user( $old_current_user );
+	}
+
+	/**
+	 * @group visibility
+	 * @expectedIncorrectUsage bp_nav
+	 *
+	 * visibility=public + status=private results in adding the item to
+	 * the nav. However, BP_Groups_Component::setup_globals() bounces the
+	 * user away from this page on a regular pageload (BP 2.0 and under)
+	 *
+	 * @see https://buddypress.trac.wordpress.org/ticket/4785
+	 */
+	public function test_visibility_public() {
+		$this->markTestSkipped();
+		$this->set_permalink_structure( '/%postname%/' );
+		$old_options_nav = buddypress()->bp_options_nav;
+		$old_current_user = get_current_user_id();
+
+		$g = self::factory()->group->create( array(
+			'status' => 'private',
+		) );
+		$g_obj = groups_get_group( $g );
+
+		$class_name = 'BPTest_Group_Extension_Visibility_Public';
+		$e = new $class_name();
+
+		// Test as non-logged-in user
+		$this->set_current_user( 0 );
+		$this->go_to( bp_get_group_url( $g_obj ) );
+		$e->_register();
+		$this->assertTrue( isset( buddypress()->bp_options_nav[ $g_obj->slug ][ $e->slug ] ) );
+
+		// Clean up
+		buddypress()->bp_options_nav = $old_options_nav;
+
+		// Test as group member
+		$u = self::factory()->user->create();
+		$this->set_current_user( $u );
+		$this->add_user_to_group( $u, $g );
+		$this->go_to( bp_get_group_url( $g_obj ) );
+		$e->_register();
+		$this->assertTrue( isset( buddypress()->bp_options_nav[ $g_obj->slug ][ $e->slug ] ) );
+
+		// Clean up
+		buddypress()->bp_options_nav = $old_options_nav;
+		$this->set_current_user( $old_current_user );
+	}
+
+	/**
+	 * @expectedIncorrectUsage bp_nav
+	 */
+	function test_nav_menu() {
+		$this->markTestSkipped();
+		$this->set_permalink_structure( '/%postname%/' );
+		$this->go_to( '/' );
+		$this->assertTrue( isset( buddypress()->bp_nav['activity'] ) );
+		$this->assertTrue( isset( buddypress()->bp_nav['profile'] ) );
+	}
+}


### PR DESCRIPTION
Fixes #13

See https://github.com/buddypress/buddypress/pull/121
Once https://buddypress.trac.wordpress.org/ticket/8927 will be fixed, let's merge this PR.