### PR TITLE
Prepare plugin 1.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Change Log
 
+## 1.2.0
+
+_Requires WordPress 5.8_
+_Tested up to WordPress 6.4_
+_Requires BuddyPress 12.0_
+_Tested up to BuddyPress 12.0_
+
+### Description
+
+This is the second maintenance release of the the BP Classic Add-on. It brings to BuddyPress (12.0.0 & up) backwards compatibility code for plugins & themes not ready yet for the BP Rewrites API.
+
+### Changes
+
+- Avoid a type mismatch issue during the migration process (See [#27](https://github.com/buddypress/bp-classic/issues/27)).
+- Only check once BuddyPress current config & version are ok (See [#28](https://github.com/buddypress/bp-classic/issues/28)).
+
+## Props
+
+@imath, @emaralive.
+
+---
+
 ## 1.1.0
 
 _Requires WordPress 5.8_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This is the second maintenance release of the the BP Classic Add-on. It brings t
 
 - Avoid a type mismatch issue during the migration process (See [#27](https://github.com/buddypress/bp-classic/issues/27)).
 - Only check once BuddyPress current config & version are ok (See [#28](https://github.com/buddypress/bp-classic/issues/28)).
+- Make sure the migration script is run on Multisite (See [#31](https://github.com/buddypress/bp-classic/issues/31)).
 
 ## Props
 

--- a/readme.txt
+++ b/readme.txt
@@ -6,8 +6,8 @@ License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Requires at least: 5.8
 Requires PHP: 5.6
-Tested up to: 6.3
-Stable tag: 1.1.0
+Tested up to: 6.4
+Stable tag: 1.2.0
 
 BP Classic, a BuddyPress (12.0.0 & up) backwards compatibility add-on
 
@@ -65,6 +65,10 @@ If you would like to provide monetary support to the BP Classic or BuddyPress pl
 
 == Upgrade Notice ==
 
+= 1.2.0 =
+
+No specific upgrade tasks needed.
+
 = 1.1.0 =
 
 No specific upgrade tasks needed.
@@ -74,6 +78,11 @@ No specific upgrade tasks needed.
 Initial version of the plugin, no upgrade needed.
 
 == Changelog ==
+
+= 1.2.0 =
+
+- Avoid a type mismatch issue during the migration process (See [#27](https://github.com/buddypress/bp-classic/issues/27)).
+- Only check once BuddyPress current config & version are ok (See [#28](https://github.com/buddypress/bp-classic/issues/28)).
 
 = 1.1.0 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -83,6 +83,7 @@ Initial version of the plugin, no upgrade needed.
 
 - Avoid a type mismatch issue during the migration process (See [#27](https://github.com/buddypress/bp-classic/issues/27)).
 - Only check once BuddyPress current config & version are ok (See [#28](https://github.com/buddypress/bp-classic/issues/28)).
+- Make sure the migration script is run on Multisite (See [#31](https://github.com/buddypress/bp-classic/issues/31)).
 
 = 1.1.0 =
 


### PR DESCRIPTION
- Bump stable tag & WP Tested up to version to 6.4
- Update changelog