### PR TITLE
Fix bbPress pagination

### DIFF
--- a/inc/forums/functions.php
+++ b/inc/forums/functions.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * BP Classic Compatibility Functions for bbPress.
+ *
+ * @package bp-classic\inc\forums
+ * @since 1.4.0
+ */
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Adjusts the `WP_Query` paged var.
+ *
+ * @since 1.4.0
+ *
+ * @param WP_Query $query The WP Query pasded by reference.
+ */
+function bp_classic_setup_forums_pagination( &$query ) {
+	if ( $query->get( 'paged' ) ) {
+		return;
+	}
+
+	if ( ( bp_is_user() && bp_is_current_component( 'forums' ) ) || ( bp_is_group() && bp_is_current_action( 'forum' ) ) ) {
+		$action_variables = (array) bp_action_variables();
+		$is_paged         = array_search( bbp_get_paged_slug(), $action_variables, true );
+
+		if ( false !== $is_paged ) {
+			$query->set( 'paged', (int) bp_action_variable( $is_paged + 1 ) );
+		}
+	}
+}
+add_action( 'bp_members_parse_query', 'bp_classic_setup_forums_pagination' );
+add_action( 'bp_groups_parse_query', 'bp_classic_setup_forums_pagination' );

--- a/inc/loader.php
+++ b/inc/loader.php
@@ -91,3 +91,13 @@ function bp_classic_template_pack_includes() {
 	}
 }
 add_action( 'bp_after_setup_theme', 'bp_classic_template_pack_includes', 1 );
+
+/**
+ * Specific compatibility functions for bbPress.
+ *
+ * @since 1.4.0
+ */
+function bp_classic_forums_includes() {
+	require trailingslashit( plugin_dir_path( __FILE__ ) ) . 'forums/functions.php';
+}
+add_action( 'bbp_buddypress_loaded', 'bp_classic_forums_includes' );


### PR DESCRIPTION
Following a discussion about [bbPress compat with BP 12.0](https://bbpress.trac.wordpress.org/ticket/3576) @boonebgorges confirmed there was an issue with BP 12.0 & forum topics/replies pagination. This issue is still there when BP Classic is active.

This PR aims to fix it until bbPress is fully compatible with BuddyPress 12.0 & up.